### PR TITLE
fix(forecast): show selected avalanches in picker modal

### DIFF
--- a/src/components/features/admin/Forecasts/ForecastForm/ForecastForm.tsx
+++ b/src/components/features/admin/Forecasts/ForecastForm/ForecastForm.tsx
@@ -86,10 +86,7 @@ const ForecastForm = ({ initialFormData, onCancel, onSuccess, regionId }: Foreca
             <hr />
             <ProblemsSection />
             <hr />
-            <RecentAvalanchesSection
-              forecastId={initialFormData.baseFormData.id}
-              regionId={regionId}
-            />
+            <RecentAvalanchesSection regionId={regionId} />
             <hr />
             <AdditionalTextFields />
           </form>

--- a/src/components/features/admin/Forecasts/ForecastForm/RecentAvalanchesSection/AvalanchePickerModal/AvalanchePickerModal.tsx
+++ b/src/components/features/admin/Forecasts/ForecastForm/RecentAvalanchesSection/AvalanchePickerModal/AvalanchePickerModal.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Button, Modal, ModalBody, ModalFooter, Spinner } from '@components/ui'
 import { useAllRecentAvalanchesQuery } from '@data/hooks/forecasts'
 import type { Avalanche, RegionId } from '@domain/types'
@@ -7,37 +7,27 @@ import { useTranslations } from 'next-intl'
 import AvalanchePickerRow from './AvalanchePickerRow'
 
 type AvalanchePickerModalProps = {
-  currentForecastId: number | undefined
   isOpen: boolean
   onClose: () => void
   onConfirm: (selected: Avalanche[]) => void
   regionId: RegionId
+  selectedAvalancheIds: number[]
 }
 
 const AvalanchePickerModal = ({
-  currentForecastId,
   isOpen,
   onClose,
   onConfirm,
   regionId,
+  selectedAvalancheIds,
 }: AvalanchePickerModalProps) => {
   const t = useTranslations()
-  const [selectedIds, setSelectedIds] = useState<Set<number>>(new Set())
+  const [selectedIds, setSelectedIds] = useState<Set<number>>(() => new Set(selectedAvalancheIds))
 
   const { data: avalanches = [], isLoading } = useAllRecentAvalanchesQuery({
     enabled: isOpen,
     regionId,
   })
-
-  const availableAvalanches = useMemo(
-    () =>
-      avalanches.filter(
-        (avalanche) =>
-          !currentForecastId ||
-          !avalanche.forecastAvalanche.some((entry) => entry.forecastId === currentForecastId),
-      ),
-    [avalanches, currentForecastId],
-  )
 
   const handleToggle = useCallback((id: number) => {
     setSelectedIds((prev) => {
@@ -54,36 +44,30 @@ const AvalanchePickerModal = ({
   }, [])
 
   const handleConfirm = useCallback(() => {
-    const selected = availableAvalanches
+    const selected = avalanches
       .filter((avalanche) => selectedIds.has(avalanche.id))
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       .map(({ forecastAvalanche, ...rest }) => rest as Avalanche)
 
     onConfirm(selected)
-    setSelectedIds(new Set())
-  }, [availableAvalanches, onConfirm, selectedIds])
-
-  const handleClose = useCallback(() => {
-    setSelectedIds(new Set())
-    onClose()
-  }, [onClose])
+  }, [avalanches, onConfirm, selectedIds])
 
   return (
     <Modal
       isOpen={isOpen}
-      onClose={handleClose}
+      onClose={onClose}
       title={t('admin.forecast.form.recentAvalanches.labels.pickAvalanches')}
     >
       <ModalBody>
         {isLoading ? (
           <Spinner />
-        ) : availableAvalanches.length === 0 ? (
+        ) : avalanches.length === 0 ? (
           <p className="py-4 text-center text-gray-500">
             {t('admin.forecast.form.recentAvalanches.labels.noAvalanchesInDB')}
           </p>
         ) : (
           <ul className="max-h-[60vh] divide-y overflow-y-auto">
-            {availableAvalanches.map((avalanche) => (
+            {avalanches.map((avalanche) => (
               <AvalanchePickerRow
                 key={avalanche.id}
                 avalanche={avalanche}
@@ -96,10 +80,10 @@ const AvalanchePickerModal = ({
       </ModalBody>
 
       <ModalFooter>
-        <Button onClick={handleClose} variant="secondary">
+        <Button onClick={onClose} variant="secondary">
           {t('common.actions.cancel')}
         </Button>
-        <Button disabled={selectedIds.size === 0} onClick={handleConfirm}>
+        <Button onClick={handleConfirm}>
           {t('admin.forecast.form.recentAvalanches.labels.addSelected', {
             count: selectedIds.size,
           })}

--- a/src/components/features/admin/Forecasts/ForecastForm/RecentAvalanchesSection/RecentAvalanchesSection.tsx
+++ b/src/components/features/admin/Forecasts/ForecastForm/RecentAvalanchesSection/RecentAvalanchesSection.tsx
@@ -10,15 +10,14 @@ import useRecentAvalanchesSection from './useRecentAvalanchesSection'
 import { initialAvalancheData } from '../constants'
 
 type RecentAvalanchesSectionProps = {
-  forecastId?: number
   regionId: RegionId
 }
 
-const RecentAvalanchesSection = ({ forecastId, regionId }: RecentAvalanchesSectionProps) => {
+const RecentAvalanchesSection = ({ regionId }: RecentAvalanchesSectionProps) => {
   const t = useTranslations()
   const {
+    avalanches,
     closePicker,
-    fields,
     formState,
     handleCreateFormOpen,
     handleDelete,
@@ -27,6 +26,7 @@ const RecentAvalanchesSection = ({ forecastId, regionId }: RecentAvalanchesSecti
     handleSubmit,
     isPickerOpen,
     openPicker,
+    selectedAvalancheIds,
     setFormState,
   } = useRecentAvalanchesSection()
 
@@ -55,7 +55,7 @@ const RecentAvalanchesSection = ({ forecastId, regionId }: RecentAvalanchesSecti
       )}
 
       <AvalanchesList
-        avalanches={fields}
+        avalanches={avalanches}
         formState={formState}
         onDelete={handleDelete}
         onFormClose={handleFormClose}
@@ -63,13 +63,15 @@ const RecentAvalanchesSection = ({ forecastId, regionId }: RecentAvalanchesSecti
         onFormSave={handleSubmit}
       />
 
-      <AvalanchePickerModal
-        currentForecastId={forecastId}
-        isOpen={isPickerOpen}
-        onClose={closePicker}
-        onConfirm={handlePickerConfirm}
-        regionId={regionId}
-      />
+      {isPickerOpen && (
+        <AvalanchePickerModal
+          isOpen={isPickerOpen}
+          onClose={closePicker}
+          onConfirm={handlePickerConfirm}
+          regionId={regionId}
+          selectedAvalancheIds={selectedAvalancheIds}
+        />
+      )}
     </section>
   )
 }

--- a/src/components/features/admin/Forecasts/ForecastForm/RecentAvalanchesSection/useRecentAvalanchesSection.ts
+++ b/src/components/features/admin/Forecasts/ForecastForm/RecentAvalanchesSection/useRecentAvalanchesSection.ts
@@ -11,7 +11,7 @@ const toDate = (value: Date | string | null): Date | null =>
 
 const useRecentAvalanchesSection = () => {
   const { control } = useFormContext<ForecastFormSchema>()
-  const { append, fields, remove, update } = useFieldArray({
+  const { append, fields, remove, replace, update } = useFieldArray({
     control,
     keyName: 'localId',
     name: 'recentAvalanches',
@@ -53,20 +53,21 @@ const useRecentAvalanchesSection = () => {
 
   const handlePickerConfirm = useCallback(
     (selected: Avalanche[]) => {
-      const existingIds = new Set(fields.map((field) => field.id).filter((id) => id != null))
+      const nonPickerFields = fields.filter((field) => field.id == null)
 
-      selected
-        .filter((avalanche) => !avalanche.id || !existingIds.has(avalanche.id))
-        .forEach((avalanche) => append({ ...avalanche, date: toDate(avalanche.date) }))
+      replace([
+        ...nonPickerFields,
+        ...selected.map((avalanche) => ({ ...avalanche, date: toDate(avalanche.date) })),
+      ])
 
       closePicker()
     },
-    [append, closePicker, fields],
+    [closePicker, fields, replace],
   )
 
   return {
+    avalanches: fields,
     closePicker,
-    fields,
     formState,
     handleCreateFormOpen,
     handleDelete,
@@ -75,6 +76,7 @@ const useRecentAvalanchesSection = () => {
     handleSubmit,
     isPickerOpen,
     openPicker,
+    selectedAvalancheIds: fields.flatMap((field) => (field.id != null ? [field.id] : [])),
     setFormState,
   }
 }

--- a/src/components/features/admin/Forecasts/ForecastForm/RecentAvalanchesSection/useRecentAvalanchesSection.ts
+++ b/src/components/features/admin/Forecasts/ForecastForm/RecentAvalanchesSection/useRecentAvalanchesSection.ts
@@ -53,13 +53,17 @@ const useRecentAvalanchesSection = () => {
 
   const handlePickerConfirm = useCallback(
     (selected: Avalanche[]) => {
-      const nonPickerFields = fields.filter((field) => field.id == null)
+      const existingFieldById = new Map(
+        fields.filter((field) => field.id != null).map((field) => [field.id, field]),
+      )
+      const manuallyCreatedFields = fields.filter((field) => field.id == null)
+      const reconciledPickerFields = selected.map((avalanche) => {
+        const existingField = avalanche.id != null ? existingFieldById.get(avalanche.id) : undefined
 
-      replace([
-        ...nonPickerFields,
-        ...selected.map((avalanche) => ({ ...avalanche, date: toDate(avalanche.date) })),
-      ])
+        return existingField ?? { ...avalanche, date: toDate(avalanche.date) }
+      })
 
+      replace([...manuallyCreatedFields, ...reconciledPickerFields])
       closePicker()
     },
     [closePicker, fields, replace],


### PR DESCRIPTION
[[BG] Forecast form: Already selected avalanche is presented in the picker via duplicate](https://app.asana.com/1/1208747886147296/project/1208747689500826/task/1214548877316346?focus=true)