### PR TITLE
fix(avalanches): date filter works incorrectly

### DIFF
--- a/src/app/[locale]/admin/recent-avalanches/useRecentAvalanchesPage.ts
+++ b/src/app/[locale]/admin/recent-avalanches/useRecentAvalanchesPage.ts
@@ -5,6 +5,7 @@ import type { DateMode } from '@data/hooks/recentAvalanches'
 import { useRecentAvalanchesPaginatedQuery } from '@data/hooks/recentAvalanches'
 import { defaultRegionId } from '@domain/constants'
 import type { RegionId } from '@domain/types'
+import { endOfDay, startOfDay } from 'date-fns'
 import { useSearchParams } from 'next/navigation'
 import { useRouter } from 'src/i18n/navigation'
 
@@ -65,12 +66,13 @@ const useRecentAvalanchesPage = () => {
   )
 
   const handleDateFromChange = useCallback(
-    (date: Date | null) => updateFilters({ dateFrom: date ? date.toISOString() : null }),
+    (date: Date | null) =>
+      updateFilters({ dateFrom: date ? startOfDay(date).toISOString() : null }),
     [updateFilters],
   )
 
   const handleDateToChange = useCallback(
-    (date: Date | null) => updateFilters({ dateTo: date ? date.toISOString() : null }),
+    (date: Date | null) => updateFilters({ dateTo: date ? endOfDay(date).toISOString() : null }),
     [updateFilters],
   )
 


### PR DESCRIPTION
[[Bug] - Avalanche records are not displayed when filtering using the Created At filter](https://app.asana.com/1/1208747886147296/task/1215466019217014?focus=true)